### PR TITLE
Fix critical error with previous version of Prestashop

### DIFF
--- a/ps_viewedproduct.php
+++ b/ps_viewedproduct.php
@@ -27,7 +27,7 @@
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
-use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
+use PrestaShop\PrestaShop\Core\Product\ProductListingPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 
 if (!defined('_PS_VERSION_')) {


### PR DESCRIPTION
This pull request fix a critical error with previous version of Prestashop

Thanks to @shacker2

https://github.com/PrestaShop/PrestaShop/issues/11655

https://www.prestashop.com/forums/topic/944580-module-ps_viewedproduct-update-from-v110-to-v120-cause-cart-stop-working-ps-1732/

https://www.prestashop.com/forums/topic/945278-error-classnotfoundexception-in-ps_viewedproductphp-line-269/
