### PR TITLE
 fix wrong namespace for ProductListingPresenter

### DIFF
--- a/ps_viewedproduct.php
+++ b/ps_viewedproduct.php
@@ -27,7 +27,7 @@
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
-use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
+use PrestaShop\PrestaShop\Core\Product\ProductListingPresenter; 
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 
 if (!defined('_PS_VERSION_')) {


### PR DESCRIPTION
I use Prestashop 1.7.2.4 and this module doesn't work. It seems that this is due to an error on a namespace. With that fix, it works for me. 