### PR TITLE
!$x and isset($x) is included in empty($x)

### DIFF
--- a/ps_viewedproduct.php
+++ b/ps_viewedproduct.php
@@ -92,7 +92,8 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
         $output = '';
 
         if (Tools::isSubmit('submitBlockViewed')) {
-            if (!($productNbr = Tools::getValue('PRODUCTS_VIEWED_NBR')) || empty($productNbr)) {
+            $productNbr = Tools::getValue('PRODUCTS_VIEWED_NBR');
+            if (empty($productNbr)) {
                 $output .= $this->displayError($this->trans(
                     'You must fill in the \'Products displayed\' field.',
                     array(),
@@ -193,7 +194,7 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
             return;
         }
 
-        if (!isset($this->context->cookie->viewed) || empty($this->context->cookie->viewed)) {
+        if (empty($this->context->cookie->viewed)) {
             return;
         }
 


### PR DESCRIPTION
!$x and isset($x) is included in empty($x)
https://stackoverflow.com/questions/7142033/php-if-val-vs-if-emptyval-is-there-any-difference/7142047

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing the PR. Every detail helps: What are you changing? Why?
| Type?             | bug fix / improvement / new feature / refacto / critical
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes {paste the issue here}.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
