### PR TITLE
Prevent cookie overflow

### DIFF
--- a/ps_viewedproduct.php
+++ b/ps_viewedproduct.php
@@ -236,6 +236,7 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
 
         if (!in_array($idProduct, $arr)) {
             $arr[] = $idProduct;
+            $arr = array_reverse(array_slice(array_reverse($arr), 0, (int) (Configuration::get('PRODUCTS_VIEWED_NBR') + 1)));
 
             $this->context->cookie->viewed = trim(implode(',', $arr), ',');
         }

--- a/ps_viewedproduct.php
+++ b/ps_viewedproduct.php
@@ -236,7 +236,7 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
 
         if (!in_array($idProduct, $arr)) {
             $arr[] = $idProduct;
-            $arr = array_reverse(array_slice(array_reverse($arr), 0, (int) (Configuration::get('PRODUCTS_VIEWED_NBR') + 1)));
+            $arr = array_reverse(array_slice(array_reverse($arr), 0, ((int) Configuration::get('PRODUCTS_VIEWED_NBR') + 1)));
 
             $this->context->cookie->viewed = trim(implode(',', $arr), ',');
         }


### PR DESCRIPTION
The module should not store the whole history of viewed products, but only as much as configured.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | "Viewed Products" module
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#26996
| How to test?  | Create a script displaying cookie contents and verify that only a limited amount of last viewed products gets stored there. For example: var_export(Context::getContext()->cookie);

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
