### PR TITLE
Adapt `ps_viewedproduct` for multiples versions of PrestaShop

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['1.7.1.2', '1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest']
+        presta-versions: ['1.7.1.2', '1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', '8.0', 'latest']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/ps_viewedproduct.php
+++ b/ps_viewedproduct.php
@@ -28,7 +28,6 @@ use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
-use PrestaShop\PrestaShop\Core\Product\ProductListingPresenter;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -266,15 +265,27 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
 
             $presenterFactory = new ProductPresenterFactory($this->context);
             $presentationSettings = $presenterFactory->getPresentationSettings();
-            $presenter = new ProductListingPresenter(
-                new ImageRetriever(
-                    $this->context->link
-                ),
-                $this->context->link,
-                new PriceFormatter(),
-                new ProductColorsRetriever(),
-                $this->context->getTranslator()
-            );
+            if (version_compare(_PS_VERSION_, '1.7.5', '>=')) {
+                $presenter = new \PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter(
+                    new ImageRetriever(
+                        $this->context->link
+                    ),
+                    $this->context->link,
+                    new PriceFormatter(),
+                    new ProductColorsRetriever(),
+                    $this->context->getTranslator()
+                );
+            } else {
+                $presenter = new \PrestaShop\PrestaShop\Core\Product\ProductListingPresenter(
+                    new ImageRetriever(
+                        $this->context->link
+                    ),
+                    $this->context->link,
+                    new PriceFormatter(),
+                    new ProductColorsRetriever(),
+                    $this->context->getTranslator()
+                );
+            }
 
             $products_for_template = [];
 

--- a/tests/phpstan/phpstan-1.7.1.2.neon
+++ b/tests/phpstan/phpstan-1.7.1.2.neon
@@ -5,3 +5,5 @@ parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie::\$viewed.#'
     - '#Call to method assign\(\) on an unknown class Smarty_Data#'
+    - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
+    - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -5,3 +5,5 @@ parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie::\$viewed.#'
     - '#Call to method assign\(\) on an unknown class Smarty_Data#'
+    - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
+    - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -5,3 +5,5 @@ parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie::\$viewed.#'
     - '#Call to method assign\(\) on an unknown class Smarty_Data#'
+    - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
+    - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -4,3 +4,5 @@ includes:
 parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie::\$viewed.#'
+    - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
+    - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'

--- a/tests/phpstan/phpstan-8.0.neon
+++ b/tests/phpstan/phpstan-8.0.neon
@@ -1,0 +1,6 @@
+includes:
+	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
+
+parameters:
+  ignoreErrors:
+    - '#Access to an undefined property Cookie::\$viewed.#'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Adapt `ps_viewedproduct` for multiples versions of PrestaShop
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Relative to PrestaShop/Prestashop#28988
| How to test?  | Try this module in version `< 1.7.4.0` and in recent version (`8.0.0`)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
