### PR TITLE
SQL query improvement to check active products

### DIFF
--- a/ps_viewedproduct.php
+++ b/ps_viewedproduct.php
@@ -248,7 +248,7 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
             $viewedProductsIds = array_diff($viewedProductsIds, [$this->currentProductId]);
         }
 
-        $activeProducts = $this->getActiveProductsIds($viewedProductsIds);
+        $activeProducts = $this->getExistingProductsIds($viewedProductsIds);
         $viewedProductsIds = array_filter($viewedProductsIds, function ($entry) use ($activeProducts) {
             return in_array($entry, $activeProducts);
         });
@@ -325,7 +325,7 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
      *
      * @return array the list of active product ids among those provided
      */
-    private function getActiveProductsIds(array $productIds = [])
+    private function getExistingProductsIds(array $productIds = [])
     {
         if (empty($productIds)) {
             return [];
@@ -333,9 +333,9 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
 
         $activeProductsQuery = Db::getInstance((bool) _PS_USE_SQL_SLAVE_)->executeS('
             SELECT p.id_product
-            FROM ' . _DB_PREFIX_ . 'product p
+            FROM ' . _DB_PREFIX_ . 'product_shop p
             WHERE p.active = 1 
-            AND p.id_product IN (' . implode(',', array_map('intval', $productIds)) . ')'
+            AND p.id_product IN (' . implode(',', array_map('intval', $productIds)) . ')' . Shop::addSqlRestriction(false, 'p')
         );
 
         return array_map(function ($entry) {

--- a/ps_viewedproduct.php
+++ b/ps_viewedproduct.php
@@ -322,6 +322,7 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
 
     /**
      * @param array $productIds List of product IDs to check
+     *
      * @return array the list of active product ids among those provided
      */
     private function getActiveProductsIds(array $productIds = [])

--- a/ps_viewedproduct.php
+++ b/ps_viewedproduct.php
@@ -248,9 +248,9 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
             $viewedProductsIds = array_diff($viewedProductsIds, [$this->currentProductId]);
         }
 
-        $existingProducts = $this->getExistingProductsIds();
-        $viewedProductsIds = array_filter($viewedProductsIds, function ($entry) use ($existingProducts) {
-            return in_array($entry, $existingProducts);
+        $activeProducts = $this->getActiveProductsIds($viewedProductsIds);
+        $viewedProductsIds = array_filter($viewedProductsIds, function ($entry) use ($activeProducts) {
+            return in_array($entry, $activeProducts);
         });
 
         return array_slice($viewedProductsIds, 0, (int) (Configuration::get('PRODUCTS_VIEWED_NBR')));
@@ -321,18 +321,24 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
     }
 
     /**
-     * @return array the list of active product ids
+     * @param array $productIds List of product IDs to check
+     * @return array the list of active product ids among those provided
      */
-    private function getExistingProductsIds()
+    private function getActiveProductsIds(array $productIds = [])
     {
-        $existingProductsQuery = Db::getInstance((bool) _PS_USE_SQL_SLAVE_)->executeS('
+        if (empty($productIds)) {
+            return [];
+        }
+
+        $activeProductsQuery = Db::getInstance((bool) _PS_USE_SQL_SLAVE_)->executeS('
             SELECT p.id_product
             FROM ' . _DB_PREFIX_ . 'product p
-            WHERE p.active = 1'
+            WHERE p.active = 1 
+            AND p.id_product IN (' . implode(',', array_map('intval', $productIds)) . ')'
         );
 
         return array_map(function ($entry) {
             return $entry['id_product'];
-        }, $existingProductsQuery);
+        }, $activeProductsQuery);
     }
 }

--- a/tests/phpstan/phpstan-1.7.1.2.neon
+++ b/tests/phpstan/phpstan-1.7.1.2.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Call to method assign\(\) on an unknown class Smarty_Data#'
     - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
     - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'
+    - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, false given.#'

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Call to method assign\(\) on an unknown class Smarty_Data#'
     - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
     - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'
+    - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, false given.#'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Call to method assign\(\) on an unknown class Smarty_Data#'
     - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
     - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'
+    - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, false given.#'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -6,3 +6,4 @@ parameters:
     - '#Access to an undefined property Cookie::\$viewed.#'
     - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
     - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'
+    - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, false given.#'

--- a/tests/phpstan/phpstan-1.7.5.1.neon
+++ b/tests/phpstan/phpstan-1.7.5.1.neon
@@ -4,3 +4,4 @@ includes:
 parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie::\$viewed.#'
+    - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, false given.#'

--- a/tests/phpstan/phpstan-1.7.6.neon
+++ b/tests/phpstan/phpstan-1.7.6.neon
@@ -4,3 +4,4 @@ includes:
 parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie::\$viewed.#'
+    - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, false given.#'

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -4,3 +4,4 @@ includes:
 parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie::\$viewed.#'
+    - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, false given.#'

--- a/tests/phpstan/phpstan-1.7.8.neon
+++ b/tests/phpstan/phpstan-1.7.8.neon
@@ -4,3 +4,4 @@ includes:
 parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie::\$viewed.#'
+    - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, false given.#'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | SQL query optimization, so "active" flag is only checked on viewed products instead of the whole catalog.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See beelow
| Related Pr | https://github.com/PrestaShop/ps_viewedproduct/pull/37

How to test :
Activate the "Viewed product" module
Turn debug profiling ON
Enter a product page
Then go to another one
Check the query in the debug profiling, it must contains "AND p.id_product IN ( .... )" with a small number of rows returned.
