### PR TITLE
Remove caching system and bump version to 2.0.0

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_viewedproduct</name>
     <displayName><![CDATA[Viewed products block]]></displayName>
-    <version><![CDATA[1.2.5]]></version>
+    <version><![CDATA[2.0.0]]></version>
     <description><![CDATA[Adds a block displaying recently viewed products.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_viewedproduct.php
+++ b/ps_viewedproduct.php
@@ -42,7 +42,7 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
     {
         $this->name = 'ps_viewedproduct';
         $this->author = 'PrestaShop';
-        $this->version = '1.2.5';
+        $this->version = '2.0.0';
         $this->tab = 'front_office_features';
         $this->need_instance = 0;
 
@@ -70,19 +70,7 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
             && Configuration::updateValue('PRODUCTS_VIEWED_NBR', 8)
             && $this->registerHook('displayFooterProduct')
             && $this->registerHook('displayProductAdditionalInfo')
-            && $this->registerHook('actionObjectProductDeleteAfter')
-            && $this->registerHook('actionObjectProductUpdateAfter')
         ;
-    }
-
-    public function hookActionObjectProductDeleteAfter($params)
-    {
-        $this->_clearCache($this->templateFile);
-    }
-
-    public function hookActionObjectProductUpdateAfter($params)
-    {
-        $this->_clearCache($this->templateFile);
     }
 
     public function getContent()
@@ -100,8 +88,6 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
                 $output .= $this->displayError($this->trans('Invalid number.', [], 'Modules.Viewedproduct.Admin'));
             } else {
                 Configuration::updateValue('PRODUCTS_VIEWED_NBR', (int) $productNbr);
-
-                $this->_clearCache($this->templateFile);
 
                 $output .= $this->displayConfirmation($this->trans(
                     'The settings have been updated.',
@@ -172,13 +158,6 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
         ];
     }
 
-    public function getCacheId($name = null)
-    {
-        $key = implode('|', $this->getViewedProductIds());
-
-        return parent::getCacheId('ps_viewedproduct|' . $key);
-    }
-
     public function renderWidget($hookName = null, array $configuration = [])
     {
         if (isset($configuration['product']['id_product'])) {
@@ -195,17 +174,15 @@ class Ps_Viewedproduct extends Module implements WidgetInterface
             return;
         }
 
-        if (!$this->isCached($this->templateFile, $this->getCacheId())) {
-            $variables = $this->getWidgetVariables($hookName, $configuration);
+        $variables = $this->getWidgetVariables($hookName, $configuration);
 
-            if (empty($variables)) {
-                return false;
-            }
-
-            $this->smarty->assign($variables);
+        if (empty($variables)) {
+            return false;
         }
 
-        return $this->fetch($this->templateFile, $this->getCacheId());
+        $this->smarty->assign($variables);
+
+        return $this->fetch($this->templateFile);
     }
 
     public function getWidgetVariables($hookName = null, array $configuration = [])

--- a/upgrade/upgrade-2.0.0.php
+++ b/upgrade/upgrade-2.0.0.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_0_0($module)
+{
+    $module->unregisterHook('actionObjectProductDeleteAfter');
+    $module->unregisterHook('actionObjectProductUpdateAfter');
+
+    return true;
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Removes caching system from this module to fix all issues with outdated data being displayed on homepage. Once you display anything more than a price on the product miniature, the data is outdated. Availability displays yesterdays date or wrong message. There is only a negligible slowdown, it's only 8 products, we load much more in a category, where there is no caching.
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Sponsor company   | TRENDO s.r.o.